### PR TITLE
Introduce Discord rights guideline

### DIFF
--- a/permissions.md
+++ b/permissions.md
@@ -1,0 +1,27 @@
+
+
+## Overview
+
+PyPSA-meets-Earth is a collaborative open source initiative dedicated to building a transparent, inclusive, and reproducible energy system modeling ecosystem, leveraging the PyPSA framework and contributing to the broader scientific and policy discourse around sustainable transitions. This document outlines the permissions to communication channels.
+
+## Rationale
+This table defines how the governance roles of PyPSA meets Earth map to Discord roles and which permissions are associated with them.
+It is intended as a practical reference for configuring and maintaining the Discord server while ensuring transparency, minimal privilege, and role‑aligned decision structures.
+Project‑ or stream‑specific channels may require additional case‑by‑case permission settings to ensure relevant contributors have access.
+Maintenance channels remain restricted to designated individuals, independent of governance roles.
+
+
+| Governance Role | Discord Role | Permissions Summary |
+| --- | --- | --- |
+| Participant | @everyone | Normal chat rights; all but "moderator only" |
+| Contributor | Contributor | Normal chat rights; all but "moderator only" |
+| Coordinator | Stream Coordinator | Moderation in own stream, private coordinator channel (?), all but "moderator only" |
+| Steering Committee | Steering Committee | Server-wide moderation, strategic channels, manage channels, access to "moderator only" |
+| Admin (technical) | Server Admin | Technical admin only, no governance authority |
+
+| Governance Role     | Discord Role        | Permissions Summary |
+|---------------------|----------------------|----------------------|
+| **Participant**     | @everyone            | Standard chat rights; access to all public channels; no moderation permissions; excluded from moderator‑only and maintenance channels. |
+| **Contributor**     | Contributor          | Standard chat rights; access to contributor-only channels; no moderation rights; excluded from moderator‑only and maintenance channels; project/stream‑specific access may be granted case‑by‑case. |
+| **Coordinator**     | Stream Coordinator   | Moderation rights within own stream; access to coordinator‑only channels (if applicable); no server‑wide moderation; extended permissions in project/stream‑specific channels possible; no access to moderator‑only or maintenance channels unless explicitly granted. |
+| **Steering Committee** | Steering Committee | Server‑wide moderation rights; access to moderator‑only channel; may manage channels where needed; access to maintenance channels.


### PR DESCRIPTION
This PR introduces a Discord rights guideline, closely linked to the governance itself.